### PR TITLE
Mapeia entidades BusRoute e BusStop com suporte a PostGIS

### DIFF
--- a/src/main/java/com/azvtech/bus_geo_api/model/BusRoute.java
+++ b/src/main/java/com/azvtech/bus_geo_api/model/BusRoute.java
@@ -1,0 +1,25 @@
+package com.azvtech.bus_geo_api.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.locationtech.jts.geom.Geometry;
+
+@Entity
+@Table(name = "bus_routes", schema = "public")
+@Data
+public class BusRoute {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long fid;
+
+    private String consorcio;
+    private String descricaoDesvio;
+    private String tipoRota;
+    private String direcao;
+    private String destino;
+    private String servico;
+    private Double extensao;
+
+    @Column(columnDefinition = "Geometry")
+    private Geometry wkbGeometry; // Geometria PostGIS
+}

--- a/src/main/java/com/azvtech/bus_geo_api/model/BusStop.java
+++ b/src/main/java/com/azvtech/bus_geo_api/model/BusStop.java
@@ -1,0 +1,19 @@
+package com.azvtech.bus_geo_api.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.locationtech.jts.geom.Point;
+
+@Entity
+@Table(name = "bus_stop", schema = "public")
+@Data
+public class BusStop {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long fid;
+
+    private String stopName;
+
+    @Column(columnDefinition = "Geometry(Point, 4326)")
+    private Point wkbGeometry; // Ponto geográfico (SRID 4326)
+}


### PR DESCRIPTION
Mapeia entidades JPA para as tabelas `bus_routes` e `bus_stop`:
- Suporte a geometrias PostGIS (Geometry e Point).
- Uso do Lombok para reduzir boilerplate.
- Resolve #2 (referência à issue criada).